### PR TITLE
BDOG-2055 fixes auth-client upgrade initiative to only count <= 5.5.0…

### DIFF
--- a/app/uk/gov/hmrc/platforminitiatives/services/PlatformInitiativesService.scala
+++ b/app/uk/gov/hmrc/platforminitiatives/services/PlatformInitiativesService.scala
@@ -79,7 +79,7 @@ class PlatformInitiativesService @Inject()(
         initiativeDescription = s"[CL250 Security upgrade required](" + url"https://catalogue.tax.service.gov.uk/dependencyexplorer/results?group=uk.gov.hmrc&artefact=auth-client&team=$teamName&flag=production&scope=compile&versionRange=[0.0.0,5.6.0)&asCsv=false".toString.replace(")", "\\)") + " ) | [Confluence](" + url"https://confluence.tools.tax.service.gov.uk/x/RgpxDw" + ").",
         group                 = "uk.gov.hmrc",
         artefact              = "auth-client",
-        version               = Version(5,6,0,"5.6.0"),
+        version               = Version(5,5,0,"5.5.0"),
         team                  = team
       ),
       createUpgradeInitiative(

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -4,8 +4,8 @@ import sbt._
 
 
 object AppDependencies {
-  val bootstrapPlayVersion = "5.23.0"
-  val hmrcMongoVersion     = "0.62.0"
+  val bootstrapPlayVersion = "7.0.0"
+  val hmrcMongoVersion     = "0.70.0"
 
   val compile = Seq(
     ws,

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.8
+sbt.version=1.6.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,6 +2,6 @@ resolvers += MavenRepository("HMRC-open-artefacts-maven2", "https://open.artefac
 resolvers += Resolver.url("HMRC-open-artefacts-ivy2", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(Resolver.ivyStylePatterns)
 resolvers += Resolver.typesafeRepo("releases")
 
-addSbtPlugin("uk.gov.hmrc"       % "sbt-auto-build"     % "3.6.0")
+addSbtPlugin("uk.gov.hmrc"       % "sbt-auto-build"     % "3.8.0")
 addSbtPlugin("uk.gov.hmrc"       % "sbt-distributables" % "2.1.0")
 addSbtPlugin("com.typesafe.play" % "sbt-plugin"         % "2.8.15")


### PR DESCRIPTION
… rather than 5.6.0